### PR TITLE
Displaying transaction type string instead of number

### DIFF
--- a/src/app/components/TxPool/TransactionTableRow.tsx
+++ b/src/app/components/TxPool/TransactionTableRow.tsx
@@ -21,6 +21,21 @@ function toMaskString(value: number): string {
 	return `0b${mask}`;
 }
 
+const getTransactionType = (type: number | null | undefined): string => {
+	if (type === null || type === undefined) return "Error: type is null";
+
+	const typeMap: { [key: number]: string } = {
+		0: "Legacy",
+		1: "Access List",
+		2: "Dynamic Fee",
+		3: "Blob",
+		4: "Set Code",
+		5: "Account Abstraction"
+	};
+
+	return typeMap[type] || `Unknown (${type})`;
+};
+
 const BaseRow: React.FC<TransactionTableRowProps> = ({ index, style, data }) => {
 	const tx = data[index];
 
@@ -99,7 +114,7 @@ const BaseRow: React.FC<TransactionTableRowProps> = ({ index, style, data }) => 
 						sm={4}
 					>
 						<Typography variant="body2">
-							<strong>Type:</strong> {tx?.tx?.type || "Legacy"}
+							<strong>Type:</strong> {getTransactionType(tx?.tx?.type)}
 						</Typography>
 					</Grid>
 					<Grid
@@ -253,7 +268,7 @@ export const DiscardedRow: React.FC<TransactionTableRowProps> = ({ index, style,
 						sm={4}
 					>
 						<Typography variant="body2">
-							<strong>Type:</strong> {tx?.tx?.type || "Legacy"}
+							<strong>Type:</strong> {getTransactionType(tx?.tx?.type)}
 						</Typography>
 					</Grid>
 					<Grid


### PR DESCRIPTION
This pull request includes updates to the `src/app/components/TxPool/TransactionTableRow.tsx` file to improve the handling and display of transaction types. The changes introduce a new function to map transaction types to human-readable strings and update the relevant components to use this new function.

Improvements to transaction type handling:

* [`src/app/components/TxPool/TransactionTableRow.tsx`](diffhunk://#diff-774383c36ad6eb0255248456ebd3fea869f981d5097374d8d7d6f532ac440244R24-R38): Added the `getTransactionType` function to map transaction type numbers to descriptive strings. This function handles cases where the type is null or undefined and maps known types to their corresponding descriptions.
* [`src/app/components/TxPool/TransactionTableRow.tsx`](diffhunk://#diff-774383c36ad6eb0255248456ebd3fea869f981d5097374d8d7d6f532ac440244L102-R117): Updated the `BaseRow` component to use the `getTransactionType` function for displaying the transaction type.
* [`src/app/components/TxPool/TransactionTableRow.tsx`](diffhunk://#diff-774383c36ad6eb0255248456ebd3fea869f981d5097374d8d7d6f532ac440244L256-R271): Updated the `DiscardedRow` component to use the `getTransactionType` function for displaying the transaction type.